### PR TITLE
Fix/valid typescript for scores & high score working as intended

### DIFF
--- a/cypress/e2e/continent-button.cy.ts
+++ b/cypress/e2e/continent-button.cy.ts
@@ -1,0 +1,5 @@
+describe("Continent Buttons", () => {
+  beforeEach(() => {
+    cy.visit("http://localhost:3000");
+  });
+});

--- a/cypress/e2e/home.cy.ts
+++ b/cypress/e2e/home.cy.ts
@@ -1,4 +1,4 @@
-describe("template spec", () => {
+describe("Open Homepage", () => {
   it("passes", () => {
     cy.visit("http://localhost:5173");
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.9.0",
+        "@types/cypress": "^1.1.3",
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
         "@vitejs/plugin-react": "^4.3.1",
@@ -1402,6 +1403,17 @@
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.20.7"
+      }
+    },
+    "node_modules/@types/cypress": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@types/cypress/-/cypress-1.1.3.tgz",
+      "integrity": "sha512-OXe0Gw8LeCflkG1oPgFpyrYWJmEKqYncBsD/J0r17r0ETx/TnIGDNLwXt/pFYSYuYTpzcq1q3g62M9DrfsBL4g==",
+      "deprecated": "This is a stub types definition for cypress (https://cypress.io). cypress provides its own type definitions, so you don't need @types/cypress installed!",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cypress": "*"
       }
     },
     "node_modules/@types/estree": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.9.0",
+    "@types/cypress": "^1.1.3",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react": "^4.3.1",

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -10,10 +10,7 @@ const App = () => {
   const [countriesData, setCountriesData] = useState<any[]>([]);
   const [currentCountry, setCurrentCountry] = useState<string>("");
   const [userScore, setUserScore] = useState<number>(0);
-  const [highScore, setHighScore] = useState<number>(() => {
-    const savedHighScore = localStorage.getItem("highScore");
-    return savedHighScore ? parseInt(savedHighScore) : 0;
-  });
+  const [highScore, setHighScore] = useState<number>(0);
   const [remainingGuesses, setRemainingGuesses] = useState(3);
   const [continentChoice, setContinentChoice] = useState<string>("Europe");
 
@@ -196,6 +193,13 @@ const App = () => {
     }
     localStorage.setItem("highScore", highScore.toString());
   }, [userScore, highScore]);
+
+  useEffect(() => {
+    const savedHighScore = localStorage.getItem("highScore");
+    if (savedHighScore) {
+      setHighScore(parseInt(savedHighScore, 10));
+    }
+  }, []);
 
   return (
     <div>

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -7,11 +7,13 @@ import Button from "../Button/Button";
 import CountryFact from "../CountryFact/CountryFact";
 
 const App = () => {
-  // Set states
   const [countriesData, setCountriesData] = useState<any[]>([]);
   const [currentCountry, setCurrentCountry] = useState<string>("");
   const [userScore, setUserScore] = useState<number>(0);
-  const [highScore, setHighScore] = useState<number>(10);
+  const [highScore, setHighScore] = useState<number>(() => {
+    const savedHighScore = localStorage.getItem("highScore");
+    return savedHighScore ? parseInt(savedHighScore) : 0;
+  });
   const [remainingGuesses, setRemainingGuesses] = useState(3);
   const [continentChoice, setContinentChoice] = useState<string>("Europe");
 
@@ -187,6 +189,13 @@ const App = () => {
   const increaseScore = () => {
     setUserScore((prevScore) => prevScore + 1);
   };
+
+  useEffect(() => {
+    if (userScore > highScore) {
+      setHighScore(userScore);
+    }
+    localStorage.setItem("highScore", highScore.toString());
+  }, [userScore, highScore]);
 
   return (
     <div>

--- a/src/components/ScoresBlock/ScoresBlock.tsx
+++ b/src/components/ScoresBlock/ScoresBlock.tsx
@@ -16,7 +16,7 @@ const ScoresBlock = ({ userScore, highScore }: ScoresBlockProps) => {
       <ScoreDisplay
         data-test="user-score"
         score={userScore}
-        displayType={"highScore"}
+        displayType={"userScore"}
       />
     </div>
   );

--- a/src/components/ScoresBlock/ScoresBlock.tsx
+++ b/src/components/ScoresBlock/ScoresBlock.tsx
@@ -1,15 +1,25 @@
 import ScoreDisplay from "./ScoresDisplay/ScoreDisplay";
 
-const ScoresBlock = ({ userScore, highScore }) => {
+type ScoresBlockProps = {
+  userScore: number;
+  highScore: number;
+};
+
+const ScoresBlock = ({ userScore, highScore }: ScoresBlockProps) => {
   return (
-    <div className=" h-[210px] w-[200px] text-center float-right mr-[21px] relative bottom-[400px]">
+    <div className="h-[210px] w-[200px] text-center float-right mr-[21px] relative bottom-[400px]">
       <ScoreDisplay
         data-test="high-score"
         displayType="highScore"
         score={highScore}
       />
-      <ScoreDisplay data-test="user-score" score={userScore} />
+      <ScoreDisplay
+        data-test="user-score"
+        score={userScore}
+        displayType={"highScore"}
+      />
     </div>
   );
 };
+
 export default ScoresBlock;

--- a/src/components/ScoresBlock/ScoresDisplay/ScoreDisplay.tsx
+++ b/src/components/ScoresBlock/ScoresDisplay/ScoreDisplay.tsx
@@ -1,5 +1,14 @@
-// ScoreDisplay component takes three props: displayType, score, and data-test
-const ScoreDisplay = ({ displayType, score, "data-test": dataTest }) => {
+type ScoreDisplayProps = {
+  displayType: "highScore" | "userScore";
+  score: number;
+  "data-test"?: string;
+};
+
+const ScoreDisplay = ({
+  displayType,
+  score,
+  "data-test": dataTest,
+}: ScoreDisplayProps) => {
   return (
     <h2 className="text-xl mb-2" data-test={dataTest}>
       {displayType === "highScore" ? "High" : "User"} score: {score}
@@ -7,4 +16,4 @@ const ScoreDisplay = ({ displayType, score, "data-test": dataTest }) => {
   );
 };
 
-export default ScoreDisplay; // Export the component for use in other parts of the app
+export default ScoreDisplay;

--- a/src/components/ScoresBlock/ScoresDisplay/ScoreDisplay.tsx
+++ b/src/components/ScoresBlock/ScoresDisplay/ScoreDisplay.tsx
@@ -1,13 +1,13 @@
-type ScoreDisplayProps = {
+interface ScoreDisplayProps {
   displayType: "highScore" | "userScore";
   score: number;
-  "data-test"?: string;
+  "data-test": string; 
 };
 
 const ScoreDisplay = ({
   displayType,
   score,
-  "data-test": dataTest,
+  "data-test": dataTest, 
 }: ScoreDisplayProps) => {
   return (
     <h2 className="text-xl mb-2" data-test={dataTest}>
@@ -17,3 +17,4 @@ const ScoreDisplay = ({
 };
 
 export default ScoreDisplay;
+

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,9 @@
   ],
 
   "compilerOptions": {
-    "module": "ES2015"
+    "module": "ES2015",
+    "target": "es5",
+    "lib": ["es5", "dom"],
+    "types": ["cypress", "node"]
   }
 }


### PR DESCRIPTION
# Merge Request: High Score Management Refactor

## Summary
This merge request refactors the high score management in the game application. I also refactored the code in the score components so that it is in typescript.

## Changes Made
- **High Score State Initialisation**: The `highScore` state is initialised with a value from `localStorage` or defaults to `0` if none exists.
- **Ensured Persistence**: The high score is now persisted across page reloads, ensuring that players can track their best scores.
- **Ensured Persistence**: Score components code refactored using "interface" to define types as discussed

```ts
interface ScoreDisplayProps {
  displayType: "highScore" | "userScore";
  score: number;
  "data-test": string; 
};
```


